### PR TITLE
fix bgp crash - defensive

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -7456,7 +7456,7 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 	/* Tunnel is newly active.
 	 * Add TIP to tip_hash of the EVPN underlay instance (bgp_get_evpn()).
 	 */
-	if (bgp_tip_add(bgp, &originator_ip))
+	if (bgp_tip_add(bgp, &originator_ip) && bgp_evpn)
 		/* The originator_ip was not already present in the
 		 * bgp martian next-hop table as a tunnel-ip, so we
 		 * need to go back and filter routes matching the new


### PR DESCRIPTION
Add a sanity to avoid null dereference of evpn state.